### PR TITLE
Use # as delimiter token for cmd arg instead of whitespace

### DIFF
--- a/components/debug_console/console.cpp
+++ b/components/debug_console/console.cpp
@@ -147,7 +147,7 @@ std::vector<std::string> Console::split(const std::string& cmd)
 
     std::vector<std::string> result;
 
-    while (std::getline(iss, buffer, ' ')) 
+    while (std::getline(iss, buffer, '#')) 
     {
         result.push_back(buffer);
     }


### PR DESCRIPTION
Command "join" does not work with SSIDs that have a whitespace - since arguments are split around whitespace. Using # instead of whitespace is a simple workaround.